### PR TITLE
add-canonical-url-functionality

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,6 +13,10 @@
 	
 	<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}">
 
+	{{ if .Params.canonicalUrl }}
+	<!-- Canonical link -->
+    <link rel="canonical" href="{{ .Params.canonicalUrl }}">
+    {{ end }}	
 	
 		
 	{{ with site.Params.author }}


### PR DESCRIPTION
Adds the ability to pass a new parameter canonicalUrl in the front matter of a post that is used to generate a canonical link in the head of the page. This will enable us to post blogs that originally appeared elsewhere with the proper attribution so that search engines do not penalize the site for duplicate content.

Signed-off-by: Erik Bledsoe <erik@calyptia.com>